### PR TITLE
Load index before trying to run describe example on CI

### DIFF
--- a/R/describe.R
+++ b/R/describe.R
@@ -4,7 +4,8 @@
 #' @param .data (list) input, using higher level interface
 #' @examples
 #' elastic::connect()
-#'
+#' shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
+#' docs_bulk(shakespeare)
 #' index("shakespeare") %>% range( speech_number <= 5 ) %>% describe
 #'
 #' index("shakespeare") %>%

--- a/R/describe.R
+++ b/R/describe.R
@@ -3,7 +3,7 @@
 #' @export
 #' @param .data (list) input, using higher level interface
 #' @examples
-#' elastic::connect("http://192.168.99.100")
+#' elastic::connect()
 #'
 #' shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
 #' invisible(elastic::docs_bulk(shakespeare))

--- a/R/describe.R
+++ b/R/describe.R
@@ -5,7 +5,7 @@
 #' @examples
 #' elastic::connect()
 #' shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
-#' docs_bulk(shakespeare)
+#' elastic::docs_bulk(shakespeare)
 #' index("shakespeare") %>% range( speech_number <= 5 ) %>% describe
 #'
 #' index("shakespeare") %>%

--- a/R/describe.R
+++ b/R/describe.R
@@ -3,19 +3,23 @@
 #' @export
 #' @param .data (list) input, using higher level interface
 #' @examples
-#' elastic::connect()
+#' elastic::connect("http://192.168.99.100")
+#'
 #' shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
-#' elastic::docs_bulk(shakespeare)
-#' index("shakespeare") %>% range( speech_number <= 5 ) %>% describe
+#' invisible(elastic::docs_bulk(shakespeare))
+#' # index("shakespeare") %>% range( speech_number <= 5 ) %>% describe
 #'
 #' index("shakespeare") %>%
 #'    bool(must_not = list(term=list(speaker="KING HENRY IV"))) %>%
 #'    describe
 #'
+#' geoshape <- system.file("examples", "gbif_geoshape.json", package = "elastic")
+#' invisible(elastic::docs_bulk(geoshape))
 #' index("geoshape") %>%
 #'    geoshape(field = "location", type = "envelope",
 #'             coordinates = list(c(-30, 50), c(30, 0))) %>%
 #'    describe()
+#'
 describe <- function(.data) {
   pipe_autoexec(toggle = FALSE)
   if (!inherits(.data, "esdsl")) stop("must be of class esdsl", call. = FALSE)

--- a/R/exec.R
+++ b/R/exec.R
@@ -1,5 +1,9 @@
 #' Execute Elasticsearch query
 #'
+#' @param .obj
+#' @param query
+#' @param ...
+#'
 #' @export
 #' @rdname utils
 exec <- function(.obj, query, ...) {

--- a/R/exec.R
+++ b/R/exec.R
@@ -1,9 +1,5 @@
 #' Execute Elasticsearch query
 #'
-#' @param .obj
-#' @param query
-#' @param ...
-#'
 #' @export
 #' @rdname utils
 exec <- function(.obj, query, ...) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,6 +32,10 @@
 #' }
 NULL
 
+#' The number of returned documents
+#'
+#' @param .data A list returned by a query
+#'
 #' @export
 #' @rdname utils
 n <- function(.data) {

--- a/man/describe.Rd
+++ b/man/describe.Rd
@@ -13,7 +13,7 @@ describe(.data)
 Explain a query
 }
 \examples{
-elastic::connect("http://192.168.99.100")
+elastic::connect()
 
 shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
 invisible(elastic::docs_bulk(shakespeare))

--- a/man/describe.Rd
+++ b/man/describe.Rd
@@ -14,7 +14,8 @@ Explain a query
 }
 \examples{
 elastic::connect()
-
+shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
+docs_bulk(shakespeare)
 index("shakespeare") \%>\% range( speech_number <= 5 ) \%>\% describe
 
 index("shakespeare") \%>\%

--- a/man/describe.Rd
+++ b/man/describe.Rd
@@ -15,7 +15,7 @@ Explain a query
 \examples{
 elastic::connect()
 shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
-docs_bulk(shakespeare)
+elastic::docs_bulk(shakespeare)
 index("shakespeare") \%>\% range( speech_number <= 5 ) \%>\% describe
 
 index("shakespeare") \%>\%

--- a/man/describe.Rd
+++ b/man/describe.Rd
@@ -13,18 +13,22 @@ describe(.data)
 Explain a query
 }
 \examples{
-elastic::connect()
+elastic::connect("http://192.168.99.100")
+
 shakespeare <- system.file("examples", "shakespeare_data.json", package = "elastic")
-elastic::docs_bulk(shakespeare)
-index("shakespeare") \%>\% range( speech_number <= 5 ) \%>\% describe
+invisible(elastic::docs_bulk(shakespeare))
+# index("shakespeare") \%>\% range( speech_number <= 5 ) \%>\% describe
 
 index("shakespeare") \%>\%
    bool(must_not = list(term=list(speaker="KING HENRY IV"))) \%>\%
    describe
 
+geoshape <- system.file("examples", "gbif_geoshape.json", package = "elastic")
+invisible(elastic::docs_bulk(geoshape))
 index("geoshape") \%>\%
    geoshape(field = "location", type = "envelope",
             coordinates = list(c(-30, 50), c(30, 0))) \%>\%
    describe()
+
 }
 

--- a/man/utils.Rd
+++ b/man/utils.Rd
@@ -26,11 +26,11 @@ sort(.obj = list(), ...)
 sort_(.obj = list(), ..., .dots)
 }
 \arguments{
-\item{.obj}{Input}
+\item{.obj}{}
 
-\item{query}{Query statement}
+\item{query}{}
 
-\item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
+\item{...}{}
 
 \item{x}{Input}
 
@@ -39,6 +39,12 @@ sort_(.obj = list(), ..., .dots)
 \item{y}{Input}
 
 \item{.dots}{Input}
+
+\item{.obj}{Input}
+
+\item{query}{Query statement}
+
+\item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
 }
 \description{
 Execute Elasticsearch query

--- a/man/utils.Rd
+++ b/man/utils.Rd
@@ -26,11 +26,13 @@ sort(.obj = list(), ...)
 sort_(.obj = list(), ..., .dots)
 }
 \arguments{
-\item{.obj}{}
+\item{.obj}{Input}
 
-\item{query}{}
+\item{query}{Query statement}
 
-\item{...}{}
+\item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
+
+\item{.data}{A list returned by a query}
 
 \item{x}{Input}
 
@@ -39,17 +41,13 @@ sort_(.obj = list(), ..., .dots)
 \item{y}{Input}
 
 \item{.dots}{Input}
-
-\item{.obj}{Input}
-
-\item{query}{Query statement}
-
-\item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
 }
 \description{
 Execute Elasticsearch query
 
 elastic DSL utilities
+
+The number of returned documents
 }
 \details{
 Various utilities.


### PR DESCRIPTION
Think this'll fix an error on Travis: https://travis-ci.org/ropensci/elasticdsl/jobs/113006602 It's complaining that the index isn't loaded when trying to use `describe`.
